### PR TITLE
feat(#69): more meaningful error messages for different sync error types

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -150,8 +150,16 @@ export default class FitPlugin extends Plugin {
 			return true;
 		} else {
 			// Generate user-friendly message from structured sync error
-			const userMessage = this.fit.getSyncErrorMessage(syncResult.error);
-			syncNotice.setMessage(userMessage, true);
+			const errorMessage = this.fit.getSyncErrorMessage(syncResult.error);
+			const fullMessage = `Sync failed: ${errorMessage}`;
+
+			// Log detailed error information for debugging
+			console.error(fullMessage, {
+				type: syncResult.error.type,
+				...(syncResult.error.details || {})
+			});
+
+			syncNotice.setMessage(fullMessage, true);
 			return false;
 		}
 	};

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -434,14 +434,28 @@ export class Fit implements IFit {
 
 	/**
      * Generate user-friendly error message from structured sync error
-     * Maintains same behavior as the previous error messaging for transition period
      */
 	getSyncErrorMessage(syncError: SyncError): string {
-		// Match behavior of previous error messaging - only two messages
-		if (syncError.type === 'remote_not_found' &&
-            (syncError.details?.source === 'getRef' || syncError.details?.source === 'getTree')) {
-			return "Failed to get ref, make sure your repo name and branch name are set correctly.";
+		// Return user-friendly message based on error type
+		switch (syncError.type) {
+			case 'network':
+				return `${syncError.detailMessage}. Please check your internet connection.`;
+
+			case 'remote_access':
+				return `${syncError.detailMessage}. Check your GitHub personal access token.`;
+
+			case 'remote_not_found':
+				return `${syncError.detailMessage}. Check your repo and branch settings.`;
+
+			case 'filesystem': {
+				return `File system error: ${syncError.detailMessage}`;
+			}
+
+			case 'unknown':
+			case 'api_error':
+			default:
+				return syncError.detailMessage;
 		}
-		return "Unable to sync, if you are not connected to the internet, turn off auto sync.";
 	}
+
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces improvements to the continuous integration (CI) and pull request (PR) check workflows.

Key changes include:

*   **Refined Type Checking Command:** The CI workflow (`ci.yml`) now explicitly uses `npm run typecheck` instead of the more general `npm run build` for type checking, clarifying the purpose of this step.
*   **Enhanced ESLint Reporting in PR Checks:**
    *   The PR checks workflow (`pr-checks.yml`) now provides more granular feedback for ESLint results.
    *   It differentiates between a completely clean linting run, a run with warnings or fixable errors (which ESLint typically indicates with an exit code of 1), and an actual execution failure of the linting process.
    *   The status summary for PR checks will now display:
        *   A green checkmark (✅) for a completely clean ESLint run.
        *   A warning icon (⚠️) if ESLint finds warnings or fixable errors, indicating issues while still allowing the check to pass.
        *   A red cross (❌) only if the ESLint command itself fails to execute.

These changes improve the clarity and detail of feedback provided by the CI/CD pipelines regarding code quality and type safety.
<!-- kody-pr-summary:end -->